### PR TITLE
Fixed Circle Kick

### DIFF
--- a/scripts/nwn/nss/mod_equip.nss
+++ b/scripts/nwn/nss/mod_equip.nss
@@ -36,7 +36,12 @@ void ApplyFeatSuperNaturalEffectsOnEquip(object oPC, object oItem){
         int bUnarmed = (GetItemInSlot(INVENTORY_SLOT_RIGHTHAND, oPC) == OBJECT_INVALID);
         int nHasEffect = GetHasSpellEffect(TASPELL_CIRCLE_KICK, oPC);
 
-        if(!nHasEffect && bUnarmed)
+        if(nHasEffect) // Always First Remove The Effect (if they have it)
+        {
+            GZRemoveSpellEffects(TASPELL_CIRCLE_KICK, oPC, FALSE);
+        }
+        
+        if(bUnarmed)  // If they are Unarmed, then apply /or/ re-apply the effect 
         {
             eEff = EffectAdditionalAttacks(1);
             SetEffectSpellId(eEff, TASPELL_CIRCLE_KICK);
@@ -44,8 +49,8 @@ void ApplyFeatSuperNaturalEffectsOnEquip(object oPC, object oItem){
 
             SendMessageToPC(oPC, C_GREEN+"Circle Kick: Bonus attack applied!"+C_END);
         }
-        else if(!bUnarmed && nHasEffect){
-            GZRemoveSpellEffects(TASPELL_CIRCLE_KICK, oPC, FALSE);
+        else  // Send them the removal message since they were NOT unarmred..
+        {
             SendMessageToPC(oPC, C_RED+"Circle Kick: Bonus attack removed!"+C_END);
         }
     }


### PR DESCRIPTION
This is the correct way to handle it, remove the effect every time they equip ANY Item, then check to see if they are unarmed. (It must be ran every time any item is equipped.)

I tested this, offline...

NOTE: you should consider removing the messages though, otherwise you will receive multiple messages OnClientEnter, when it unequips & equips all of the items on the PC...
